### PR TITLE
Add Makefile and upgrade workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: gautamkrishnar/keepalive-workflow@v1
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -46,7 +44,7 @@ jobs:
 
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           pip install localstack awscli-local[ver1]
           docker pull localstack/localstack-pro:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: gautamkrishnar/keepalive-workflow@v1
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION=us-east-1
+SHELL := /bin/bash
+
+usage:		## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+install:	## Install dependencies
+	@which localstack || pip install localstack
+	@which awslocal || pip install awscli-local
+	virtualenv env
+	. env/bin/activate && pip install -r requirements.txt
+
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+
+stop:		## Stop LocalStack
+	@localstack stop
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
+
+deploy:		## Deploy the CDK stack
+	cdklocal bootstrap
+	cdklocal deploy --require-approval never
+
+.PHONY: usage install start stop ready logs deploy

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ The sample code in this repository demonstrates how to use the ECS Code Mounting
 
 ## Prerequisites
 
-- LocalStack Pro with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
+- LocalStack with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [Cloud Development Kit](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://www.npmjs.com/package/aws-cdk-local) installed.
 - [Python 3.9+](https://www.python.org/downloads/) & `pip` package manager.
 - [`virtualenv`](https://pypi.org/project/virtualenv/) for creating isolated Python environments.
 - `cURL` or any other tool to send HTTP requests.
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```shell
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ The sample code in this repository demonstrates how to use the ECS Code Mounting
 
 ## Prerequisites
 
-- LocalStack with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [Cloud Development Kit](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://www.npmjs.com/package/aws-cdk-local) installed.
 - [Python 3.9+](https://www.python.org/downloads/) & `pip` package manager.
 - [`virtualenv`](https://pypi.org/project/virtualenv/) for creating isolated Python environments.
 - `cURL` or any other tool to send HTTP requests.
-- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 
 Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 


### PR DESCRIPTION
## Summary
- Add Makefile with `start`, `stop`, `ready`, `logs`, `deploy` targets
- Upgrade `actions/checkout@v3` to `v4`, `actions/setup-node@v3` to `v4`
- Replace deprecated `LOCALSTACK_API_KEY` with `LOCALSTACK_AUTH_TOKEN` in workflow
- Remove `keepalive-workflow` action